### PR TITLE
Refactored the Checkmate API Client

### DIFF
--- a/internal/api/checkmate/auth.go
+++ b/internal/api/checkmate/auth.go
@@ -1,0 +1,15 @@
+package checkmate
+
+type Authenticator struct {
+	key       string
+	headerKey string
+	header    string
+}
+
+func NewBearerAuthenticator(credentials string) *Authenticator {
+	return &Authenticator{
+		key:       credentials,
+		headerKey: "Authorization",
+		header:    "Bearer ",
+	}
+}

--- a/internal/api/checkmate/client.go
+++ b/internal/api/checkmate/client.go
@@ -1,6 +1,7 @@
 package checkmate
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -16,21 +17,57 @@ import (
 //
 // [Checkmate Server OpenAPI Specs]: https://github.com/bluewave-labs/Checkmate/blob/develop/Server/openapi.json
 type CheckmateClient struct {
-	credentials *config.Credentials
-	httpClient  *http.Client
+	credentials   *config.Credentials
+	httpClient    *http.Client
+	authenticator *Authenticator
 }
 
-func (c *CheckmateClient) SendRequest(req *http.Request) (*http.Response, error) {
-	return c.httpClient.Do(req)
+func (c *CheckmateClient) performRequest(method string, path string, payload any, auth *Authenticator) (*types.APIResponse, error) {
+	var requestBody []byte
+	var err error
+	var req *http.Request
+
+	if method == http.MethodGet {
+		req, err = http.NewRequest(method, c.credentials.APIBaseURL+path, nil)
+	} else {
+		requestBody, err = json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body := bytes.NewBuffer(requestBody)
+		req, err = http.NewRequest(method, c.credentials.APIBaseURL+path, body)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(auth.headerKey, auth.header+c.credentials.APIKey)
+
+	response, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := responseStatusCodeHandler(response); err != nil {
+		return nil, err
+	}
+
+	return bodyParser(response.Body)
 }
 
-func NewCheckmateClient(credentials *config.Credentials, httpClient *http.Client) *CheckmateClient {
+func NewCheckmateClient(credentials *config.Credentials, httpClient *http.Client, authenticator *Authenticator) *CheckmateClient {
 	return &CheckmateClient{
-		credentials: credentials,
-		httpClient:  httpClient,
+		credentials:   credentials,
+		httpClient:    httpClient,
+		authenticator: authenticator,
 	}
 }
 
+// Checkmate Client has pre-defined error objects for common HTTP status codes.
+// It returns an error object based on the HTTP status code of the response.
+// If no error is found, it returns nil.
 func responseStatusCodeHandler(response *http.Response) error {
 	if response == nil {
 		return errors.New("response is nil")
@@ -47,17 +84,23 @@ func responseStatusCodeHandler(response *http.Response) error {
 		return types.ErrBadRequest
 	case http.StatusUnprocessableEntity:
 		return types.ErrUnprocessableEntity
-	default:
-		if response.StatusCode >= 400 && response.StatusCode < 500 {
-			return types.ErrClientError
-		} else if response.StatusCode >= 500 {
-			return types.ErrServerError
-		}
 	}
 
 	return nil
 }
 
+// Checkmate API returns a structured response in JSON format.
+//
+// Successful response:
+//
+//	success: bool
+//	msg: string
+//	data: any (nullable)
+//
+// Error response:
+//
+//	success: bool
+//	msg: string
 func bodyParser(body io.ReadCloser) (*types.APIResponse, error) {
 	if body == nil {
 		return nil, errors.New("response body is nil")

--- a/internal/api/checkmate/client.go
+++ b/internal/api/checkmate/client.go
@@ -27,7 +27,7 @@ func (c *CheckmateClient) performRequest(method string, path string, payload any
 	var err error
 	var req *http.Request
 
-	if method == http.MethodGet {
+	if method == http.MethodGet || method == http.MethodDelete {
 		req, err = http.NewRequest(method, c.credentials.APIBaseURL+path, nil)
 	} else {
 		requestBody, err = json.Marshal(payload)

--- a/internal/api/checkmate/client.go
+++ b/internal/api/checkmate/client.go
@@ -1,8 +1,12 @@
 package checkmate
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
+	"github.com/bluewave-labs/checkmate-cli/internal/api/checkmate/types"
 	"github.com/bluewave-labs/checkmate-cli/internal/config"
 )
 
@@ -25,4 +29,50 @@ func NewCheckmateClient(credentials *config.Credentials, httpClient *http.Client
 		credentials: credentials,
 		httpClient:  httpClient,
 	}
+}
+
+func responseStatusCodeHandler(response *http.Response) error {
+	if response == nil {
+		return errors.New("response is nil")
+	}
+
+	switch response.StatusCode {
+	case http.StatusForbidden:
+		return types.ErrForbidden
+	case http.StatusUnauthorized:
+		return types.ErrUnauthorized
+	case http.StatusNotFound:
+		return types.ErrNotFound
+	case http.StatusBadRequest:
+		return types.ErrBadRequest
+	case http.StatusUnprocessableEntity:
+		return types.ErrUnprocessableEntity
+	default:
+		if response.StatusCode >= 400 && response.StatusCode < 500 {
+			return types.ErrClientError
+		} else if response.StatusCode >= 500 {
+			return types.ErrServerError
+		}
+	}
+
+	return nil
+}
+
+func bodyParser(body io.ReadCloser) (*types.APIResponse, error) {
+	if body == nil {
+		return nil, errors.New("response body is nil")
+	}
+	defer body.Close()
+
+	var apiResponse types.APIResponse
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(bodyBytes, &apiResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &apiResponse, nil
 }

--- a/internal/api/checkmate/client.go
+++ b/internal/api/checkmate/client.go
@@ -43,7 +43,10 @@ func (c *CheckmateClient) performRequest(method string, path string, payload any
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(auth.headerKey, auth.header+c.credentials.APIKey)
+
+	if auth != nil {
+		req.Header.Set(auth.headerKey, auth.header+c.credentials.APIKey)
+	}
 
 	response, err := c.httpClient.Do(req)
 	if err != nil {

--- a/internal/api/checkmate/monitor.go
+++ b/internal/api/checkmate/monitor.go
@@ -1,191 +1,40 @@
 package checkmate
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	"github.com/bluewave-labs/checkmate-cli/internal/api/checkmate/types"
 )
 
 // CreateMonitor creates a new monitor
 func (c *CheckmateClient) CreateMonitor(monitor *types.Monitor) (*types.APIResponse, error) {
-	validationErr := monitor.Validate()
-	if validationErr != nil {
-		return nil, validationErr
-	}
-
-	var requestBody []byte
-
-	requestBody, err := json.Marshal(monitor)
-	if err != nil {
+	if err := monitor.Validate(); err != nil {
 		return nil, err
 	}
 
-	body := bytes.NewBuffer(requestBody)
-	req, err := http.NewRequest("POST", c.credentials.APIBaseURL+"/monitors", body)
-
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
-	}
-
-	response, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	err = responseStatusCodeHandler(response)
-	if err != nil {
-		return nil, err
-	}
-
-	apiResponse, err := bodyParser(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Print the response body as a string
-	return apiResponse, nil
+	return c.performRequest("POST", "/monitors", monitor, c.authenticator)
 }
 
 // GetMonitor retrieves a monitor by ID
 func (c *CheckmateClient) GetMonitor(id string) (*types.APIResponse, error) {
-	req, err := http.NewRequest("GET", c.credentials.APIBaseURL+"/monitors/"+id, nil)
-
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
-	}
-
-	response, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	err = responseStatusCodeHandler(response)
-	if err != nil {
-		return nil, err
-	}
-
-	apiResponse, err := bodyParser(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Print the response body as a string
-	return apiResponse, nil
+	return c.performRequest("GET", "/monitors/"+id, nil, c.authenticator)
 }
 
 // GetAllMonitors retrieves all monitors
 func (c *CheckmateClient) GetAllMonitors() (*types.APIResponse, error) {
-	req, err := http.NewRequest("GET", c.credentials.APIBaseURL+"/monitors/", nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
-	}
-
-	response, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	err = responseStatusCodeHandler(response)
-	if err != nil {
-		return nil, err
-	}
-
-	apiResponse, err := bodyParser(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Print the response body as a string
-	return apiResponse, nil
+	return c.performRequest("GET", "/monitors", nil, c.authenticator)
 }
 
 // UpdateMonitor updates an existing monitor
 func (c *CheckmateClient) UpdateMonitor(id string, monitor *types.Monitor) (*types.APIResponse, error) {
-	var requestBody []byte
-
-	requestBody, err := json.Marshal(monitor)
-	if err != nil {
+	if err := monitor.Validate(); err != nil {
 		return nil, err
 	}
 
-	body := bytes.NewBuffer(requestBody)
-	req, err := http.NewRequest("PUT", c.credentials.APIBaseURL+"/monitors/"+id, body)
-
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
-	}
-
-	response, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	err = responseStatusCodeHandler(response)
-	if err != nil {
-		return nil, err
-	}
-
-	apiResponse, err := bodyParser(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Print the response body as a string
-	return apiResponse, nil
+	return c.performRequest("PUT", "/monitors/"+id, monitor, c.authenticator)
 }
 
 // DeleteMonitor deletes a monitor by ID
 func (c *CheckmateClient) DeleteMonitor(id string) (*types.APIResponse, error) {
-	req, err := http.NewRequest("DELETE", c.credentials.APIBaseURL+"/monitors/"+id, nil)
-
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
-	}
-
-	response, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	err = responseStatusCodeHandler(response)
-	if err != nil {
-		return nil, err
-	}
-
-	apiResponse, err := bodyParser(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Print the response body as a string
-	return apiResponse, nil
+	return c.performRequest("DELETE", "/monitors/"+id, nil, c.authenticator)
 }
 
 func (c *CheckmateClient) CreateBulkMonitors(monitors []types.Monitor) (*types.APIResponse, error) {
@@ -196,40 +45,5 @@ func (c *CheckmateClient) CreateBulkMonitors(monitors []types.Monitor) (*types.A
 		}
 	}
 
-	var requestBody []byte
-
-	requestBody, err := json.Marshal(monitors)
-	if err != nil {
-		return nil, err
-	}
-
-	body := bytes.NewBuffer(requestBody)
-	req, err := http.NewRequest("POST", c.credentials.APIBaseURL+"/monitors/bulk", body)
-
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	if c.credentials.APIKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
-	}
-
-	response, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-
-	err = responseStatusCodeHandler(response)
-	if err != nil {
-		return nil, err
-	}
-
-	apiResponse, err := bodyParser(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	// Print the response body as a string
-	return apiResponse, nil
+	return c.performRequest("POST", "/monitors/bulk", monitors, c.authenticator)
 }

--- a/internal/api/checkmate/monitor.go
+++ b/internal/api/checkmate/monitor.go
@@ -3,14 +3,13 @@ package checkmate
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/bluewave-labs/checkmate-cli/internal/api/checkmate/types"
 )
 
 // CreateMonitor creates a new monitor
-func (c *CheckmateClient) CreateMonitor(monitor *types.Monitor) (*http.Response, error) {
+func (c *CheckmateClient) CreateMonitor(monitor *types.Monitor) (*types.APIResponse, error) {
 	validationErr := monitor.Validate()
 	if validationErr != nil {
 		return nil, validationErr
@@ -35,11 +34,27 @@ func (c *CheckmateClient) CreateMonitor(monitor *types.Monitor) (*http.Response,
 		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
 	}
 
-	return c.SendRequest(req)
+	response, err := c.SendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = responseStatusCodeHandler(response)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResponse, err := bodyParser(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print the response body as a string
+	return apiResponse, nil
 }
 
 // GetMonitor retrieves a monitor by ID
-func (c *CheckmateClient) GetMonitor(id string) (*http.Response, error) {
+func (c *CheckmateClient) GetMonitor(id string) (*types.APIResponse, error) {
 	req, err := http.NewRequest("GET", c.credentials.APIBaseURL+"/monitors/"+id, nil)
 
 	if err != nil {
@@ -51,13 +66,28 @@ func (c *CheckmateClient) GetMonitor(id string) (*http.Response, error) {
 		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
 	}
 
-	return c.SendRequest(req)
+	response, err := c.SendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = responseStatusCodeHandler(response)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResponse, err := bodyParser(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print the response body as a string
+	return apiResponse, nil
 }
 
 // GetAllMonitors retrieves all monitors
 func (c *CheckmateClient) GetAllMonitors() (*types.APIResponse, error) {
 	req, err := http.NewRequest("GET", c.credentials.APIBaseURL+"/monitors/", nil)
-
 	if err != nil {
 		return nil, err
 	}
@@ -67,43 +97,27 @@ func (c *CheckmateClient) GetAllMonitors() (*types.APIResponse, error) {
 		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
 	}
 
-	monitorResponse, err := c.SendRequest(req)
-	if err != nil {
-		return nil, err
-	}
-	switch monitorResponse.StatusCode {
-	case http.StatusForbidden:
-		return nil, types.ErrForbidden
-	case http.StatusUnauthorized:
-		return nil, types.ErrUnauthorized
-	case http.StatusNotFound:
-		return nil, types.ErrNotFound
-	case http.StatusBadRequest:
-		return nil, types.ErrBadRequest
-	case http.StatusUnprocessableEntity:
-		return nil, types.ErrUnprocessableEntity
-	}
-
-	defer monitorResponse.Body.Close()
-
-	var apiResponse types.APIResponse
-	// Read the response body
-	body, err := io.ReadAll(monitorResponse.Body)
+	response, err := c.SendRequest(req)
 	if err != nil {
 		return nil, err
 	}
 
-	err = json.Unmarshal(body, &apiResponse)
+	err = responseStatusCodeHandler(response)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResponse, err := bodyParser(response.Body)
 	if err != nil {
 		return nil, err
 	}
 
 	// Print the response body as a string
-	return &apiResponse, nil
+	return apiResponse, nil
 }
 
 // UpdateMonitor updates an existing monitor
-func (c *CheckmateClient) UpdateMonitor(id string, monitor *types.Monitor) (*http.Response, error) {
+func (c *CheckmateClient) UpdateMonitor(id string, monitor *types.Monitor) (*types.APIResponse, error) {
 	var requestBody []byte
 
 	requestBody, err := json.Marshal(monitor)
@@ -123,11 +137,27 @@ func (c *CheckmateClient) UpdateMonitor(id string, monitor *types.Monitor) (*htt
 		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
 	}
 
-	return c.SendRequest(req)
+	response, err := c.SendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = responseStatusCodeHandler(response)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResponse, err := bodyParser(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print the response body as a string
+	return apiResponse, nil
 }
 
 // DeleteMonitor deletes a monitor by ID
-func (c *CheckmateClient) DeleteMonitor(id string) (*http.Response, error) {
+func (c *CheckmateClient) DeleteMonitor(id string) (*types.APIResponse, error) {
 	req, err := http.NewRequest("DELETE", c.credentials.APIBaseURL+"/monitors/"+id, nil)
 
 	if err != nil {
@@ -139,10 +169,26 @@ func (c *CheckmateClient) DeleteMonitor(id string) (*http.Response, error) {
 		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
 	}
 
-	return c.SendRequest(req)
+	response, err := c.SendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = responseStatusCodeHandler(response)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResponse, err := bodyParser(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print the response body as a string
+	return apiResponse, nil
 }
 
-func (c *CheckmateClient) CreateBulkMonitors(monitors []types.Monitor) (*http.Response, error) {
+func (c *CheckmateClient) CreateBulkMonitors(monitors []types.Monitor) (*types.APIResponse, error) {
 	// Validate each monitor
 	for _, monitor := range monitors {
 		if err := monitor.Validate(); err != nil {
@@ -169,5 +215,21 @@ func (c *CheckmateClient) CreateBulkMonitors(monitors []types.Monitor) (*http.Re
 		req.Header.Set("Authorization", "Bearer "+c.credentials.APIKey)
 	}
 
-	return c.SendRequest(req)
+	response, err := c.SendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = responseStatusCodeHandler(response)
+	if err != nil {
+		return nil, err
+	}
+
+	apiResponse, err := bodyParser(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Print the response body as a string
+	return apiResponse, nil
 }

--- a/internal/api/checkmate/types/monitor.go
+++ b/internal/api/checkmate/types/monitor.go
@@ -24,6 +24,8 @@ var ErrUnauthorized = errors.New("401 unauthorized. Please make sure you are log
 var ErrNotFound = errors.New("404 not found. Please make sure you are using the correct endpoint.")
 var ErrBadRequest = errors.New("400 bad request.")
 var ErrUnprocessableEntity = errors.New("422 unprocessable entity. Please make sure you are using the correct data format.")
+var ErrClientError = errors.New("4xx client side error occured.")
+var ErrServerError = errors.New("5xx server side error occured.")
 
 // This struct represents a monitor object.
 // Validations are done using the go-playground/validator package to ensure that the monitor data is valid.

--- a/internal/api/checkmate/types/types.go
+++ b/internal/api/checkmate/types/types.go
@@ -1,1 +1,7 @@
 package types
+
+type APIResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"msg"`
+	Data    any    `json:"data"`
+}


### PR DESCRIPTION
## Refactor the Checkmate Client

### Client Refactor

Each method has the base requirements like setting up the request headers, returning errors according to status code and parsing the body if the request is successful. Moved the "duplicated" logics to the performRequest method. It's widely extendable and easy to define and use.

```golang
...
// Send a GET request to /monitors route with payload and authentication headers.
c.performRequest("POST", "/monitors", monitor, c.authenticator)

// Send a GET request to public route without any payload or authentication header.
c.performRequest("GET", "/public", nil, nil)
```

### Authentication

Current Checkmate API only supports **Bearer Authenticaton** with Authorization key but decisions can change. To support multi authentication systems and headers I created another `Authentication` struct.

for example using `X-API-Key` header instead of `Authorization`

### Constant Errors and Typings

Add new 2 different pre-defined errors for the 

- ErrClientError
- ErrServerError

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced secure token-based authentication for improved access control.
  - Added structured API responses that clearly indicate success status, messages, and related data.

- **Refactor**
  - Unified the process for handling API requests, resulting in more reliable interactions.
  - Enhanced error reporting with distinct notifications for client and server issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->