### PR TITLE
Update API documentation links to point to the backend repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,4 +24,4 @@ It regularly checks whether a server/website is accessible and performs optimall
 
 Checkmate's API is documented in accordance with the OpenAPI spec.
 
-Use this [checkmate-openapi-specs](https://github.com/bluewave-labs/Checkmate/blob/develop/Server/openapi.json) for the API documentation.
+Use this [checkmate-openapi-specs](https://github.com/bluewave-labs/checkmate-backend/blob/master/openapi.json) for the API documentation.

--- a/internal/api/checkmate/client.go
+++ b/internal/api/checkmate/client.go
@@ -15,7 +15,7 @@ import (
 // It is used to send HTTP requests to the Checkmate API.
 // See [Checkmate Server OpenAPI Specs] for more details.
 //
-// [Checkmate Server OpenAPI Specs]: https://github.com/bluewave-labs/Checkmate/blob/develop/Server/openapi.json
+// [Checkmate Server OpenAPI Specs]: https://github.com/bluewave-labs/checkmate-backend/blob/master/openapi.json
 type CheckmateClient struct {
 	credentials   *config.Credentials
 	httpClient    *http.Client


### PR DESCRIPTION
Checkmate monorepo separated to 2 repositores
[Checkmate](https://github.com/bluewave-labs/Checkmate) for the client side
[checkmate-backend](https://github.com/bluewave-labs/checkmate-backend) for the server side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API documentation URL to point to the new backend repository location. This change ensures all users have access to the latest API reference without affecting any functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->